### PR TITLE
Move sensitive data to POST body. 

### DIFF
--- a/spammo/auth.py
+++ b/spammo/auth.py
@@ -89,9 +89,9 @@ def two_factor(redirect_url, auth_request, csrftoken2):
         'via': 'sms',
         'csrftoken2': csrftoken2,
     }
-    url = '{}?{}'.format(spammo.settings.TWO_FACTOR_URL, urlencode(data))
     response = spammo.singletons.session().post(
-        url,
+        spammo.settings.TWO_FACTOR_URL,
+        json=data,
         headers=headers,
     )
     assert response.status_code == 200, 'Post to 2FA failed'
@@ -240,9 +240,10 @@ def submit_credentials(email, password):
         'auth_request': auth_request,
         'grant': 1,
     }
-    url = '{}?{}'.format(spammo.settings.AUTHORIZATION_URL,
-                         urlencode(data))
-    response = spammo.singletons.session().post(url, allow_redirects=False)
+    response = spammo.singletons.session().post(
+        spammo.settings.AUTHORIZATION_URL,
+        json=data,
+        allow_redirects=False)
     if response.status_code != 302:
         logger.error('expecting a redirect')
         return False

--- a/spammo/payment.py
+++ b/spammo/payment.py
@@ -75,7 +75,8 @@ def _pay_or_charge(user, amount, note):
 	    params["amount"] = payments[i]
 	    i = i+1
 	    response = spammo.singletons.session().post(
-	        _payments_url_with_params(params)
+            spammo.settings.PAYMENTS_URL,
+            json=params
 	    )
 	    data = response.json()
 
@@ -109,10 +110,3 @@ def _pay_or_charge(user, amount, note):
 	           .format(**locals()))
 
     print("You just sent a total of $"+str(finalAmount)+" in "+str(len(payments))+" payments of $"+str(payments[0])+". I hope you're happy.")
-
-
-def _payments_url_with_params(params):
-    return '{payments_base_url}?{params}'.format(
-        payments_base_url=spammo.settings.PAYMENTS_URL,
-        params=urlencode(params),
-    )


### PR DESCRIPTION
Move sensitive data to POST body. Particularly, passwords should not be passed as a query parameter.